### PR TITLE
Bare minimum changes to make mbes compile on debian

### DIFF
--- a/audio.cc
+++ b/audio.cc
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/audio.cc
+++ b/audio.cc
@@ -3,9 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-
 #include "audio.hh"
 
 const char* al_err_str(ALenum err) {

--- a/audio.hh
+++ b/audio.hh
@@ -2,8 +2,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef MACOSX
 #include <OpenAL/al.h>
 #include <OpenAL/alc.h>
+#else
+#include <AL/al.h>
+#include <AL/alc.h>
+#endif
 
 void init_al();
 void exit_al();

--- a/level.cc
+++ b/level.cc
@@ -67,7 +67,7 @@ bool cell_state::is_dude() const {
   return (this->type == ItemDude) || (this->type == BombDude);
 }
 
-explosion_type cell_state::explosion_type() const {
+explosion_type cell_state::get_explosion_type() const {
   if (this->type == ItemDude || this->type == BlueBomb)
     return ItemExplosion;
   if (this->type == GrayBomb)
@@ -317,9 +317,9 @@ uint64_t level_state::exec_frame(enum player_impulse impulse) {
           this->at(x, y + 1) = cell_state(this->at(x, y).type, Falling, true);
           this->at(x, y) = cell_state(Empty);
         } else if (this->at(x, y + 1).is_volatile() && (this->at(x, y).param == Falling)) {
-          this->pending_explosions.emplace_back(x, y + 1, 1, 0, this->at(x, y + 1).explosion_type());
+          this->pending_explosions.emplace_back(x, y + 1, 1, 0, this->at(x, y + 1).get_explosion_type());
         } else if ((this->at(x, y).type == GreenBomb || this->at(x, y).type == BlueBomb || this->at(x, y).type == GrayBomb) && (this->at(x, y).param == Falling)) {
-          this->pending_explosions.emplace_back(x, y, 1, 2, this->at(x, y).explosion_type());
+          this->pending_explosions.emplace_back(x, y, 1, 2, this->at(x, y).get_explosion_type());
           this->at(x, y).param = Resting;
         } else {
           if (this->at(x, y).param == Falling)
@@ -407,7 +407,7 @@ uint64_t level_state::exec_frame(enum player_impulse impulse) {
         for (int xx = -it->size; xx <= it->size; xx++) {
           if (this->at(it->x + xx, it->y + yy).destroyable()) {
             if ((xx || yy) && this->at(it->x + xx, it->y + yy).is_volatile()) {
-              explosion_type new_type = this->at(it->x + xx, it->y + yy).explosion_type();
+              explosion_type new_type = this->at(it->x + xx, it->y + yy).get_explosion_type();
               if (it->type == ItemExplosion)
                 new_type = ItemExplosion;
               if (it->type == RockExplosion)

--- a/level.cc
+++ b/level.cc
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/time.h>

--- a/level.hh
+++ b/level.hh
@@ -94,7 +94,7 @@ struct cell_state {
   bool is_pushable_horizontal() const;
   bool is_pushable_vertical() const;
   bool is_dude() const;
-  explosion_type explosion_type() const;
+  explosion_type get_explosion_type() const;
   bool is_left_portal() const;
   bool is_right_portal() const;
   bool is_up_portal() const;

--- a/level_completion.cc
+++ b/level_completion.cc
@@ -1,3 +1,4 @@
+#include <stdint.h>
 #include <stdio.h>
 
 #include <stdexcept>

--- a/main.cc
+++ b/main.cc
@@ -7,7 +7,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef MACOSX
 #include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #include <GLFW/glfw3.h>
 
 #include <list>
@@ -696,6 +699,7 @@ int main(int argc, char* argv[]) {
   level_index = (argc > 2) ? atoi(argv[2]) : -1;
 
   if (!level_filename) {
+#ifdef MACOSX
     CFURLRef app_url = CFBundleCopyBundleURL(CFBundleGetMainBundle());
     CFStringRef path = CFURLCopyFileSystemPath(app_url, kCFURLPOSIXPathStyle);
     const char *p = CFStringGetCStringPtr(path, CFStringGetSystemEncoding());
@@ -713,6 +717,10 @@ int main(int argc, char* argv[]) {
 
     CFRelease(app_url);
     CFRelease(path);
+#else
+    // assume it's in the same working directory for now
+    levels_filename = "levels.mbl";
+#endif
   }
 
   try {

--- a/main.cc
+++ b/main.cc
@@ -1,4 +1,5 @@
 #include <pwd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/param.h>


### PR DESCRIPTION
No autoconf or packaging script, but now you can run make -f Makefile.linux and it wil build a working mbes executable assuming you have the dependencies installed.

Also depends on the level filename either being in the working directory when you execute mbes, or being specified on the command line.
